### PR TITLE
Database cleanup and rebuild

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -41,7 +41,7 @@
 	},
 	{
 		"caption": "Cscope: Rebuild database",
-		"command": "database",
+		"command": "cscope_database",
 		"args": { "operation": "rebuild" }
 	}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,41 +2,46 @@
 	{
 		"caption": "Cscope: Look up symbol",
 		"command": "cscope",
-		"args": {"mode": 0}
+		"args": { "mode": 0 }
 	},
-  {
-    "caption": "Cscope: Look up global definition",
-    "command": "cscope",
-		"args": {"mode": 1}
-  },
-  {
-  	"caption": "Cscope: Look up functions called by this function",
-  	"command": "cscope",
-  	"args": {"mode": 2}
-  },
-  {
-  	"caption": "Cscope: Look up functions calling this function",
-  	"command": "cscope",
-  	"args": { "mode": 3 }
-  },
-  {
-    "caption": "Cscope: Search for text string",
-    "command": "cscope",
-    "args": { "mode": 4 }
-  },
-  {
-    "caption": "Cscope: Search using egrep pattern",
-    "command": "cscope",
-    "args": { "mode": 6 }
-  },
-  {
-    "caption": "Cscope: Find file",
-    "command": "cscope",
-    "args": { "mode": 7 }
-  },
-  {
-    "caption": "Cscope: Find files #including a file",
-    "command": "cscope",
-    "args": { "mode": 8 }
-  }
+	{
+		"caption": "Cscope: Look up global definition",
+		"command": "cscope",
+		"args": { "mode": 1 }
+	},
+	{
+		"caption": "Cscope: Look up functions called by this function",
+		"command": "cscope",
+		"args": { "mode": 2 }
+	},
+	{
+		"caption": "Cscope: Look up functions calling this function",
+		"command": "cscope",
+		"args": { "mode": 3 }
+	},
+	{
+		"caption": "Cscope: Search for text string",
+		"command": "cscope",
+		"args": { "mode": 4 }
+	},
+	{
+		"caption": "Cscope: Search using egrep pattern",
+		"command": "cscope",
+		"args": { "mode": 6 }
+	},
+	{
+		"caption": "Cscope: Find file",
+		"command": "cscope",
+		"args": { "mode": 7 }
+	},
+	{
+		"caption": "Cscope: Find files #including a file",
+		"command": "cscope",
+		"args": { "mode": 8 }
+	},
+	{
+		"caption": "Cscope: Rebuild database",
+		"command": "database",
+		"args": { "operation": "rebuild" }
+	}
 ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This plugin supports the majority of the functionality offered by Cscope, namely
 7. Find a given file
 8. Find files #including a given file
 
+This plugin also allows the user to rebuild the Cscope database from inside Sublime Text.
+
 ## Installation
 1. Install Cscope (a Windows port can be found [here](http://code.google.com/p/cscope-win32))
 2. Customize the cscope executable path as explained in the Configuration section below, if needed.

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -1,0 +1,10 @@
+[
+     {
+         "caption": "Cscope: Rebuild database",
+         "command": "cscope_database",
+         "args": { "operation": "rebuild" }
+     },
+     {
+         "caption": "-", "id": "cscope"
+     }
+ ]

--- a/cscope.py
+++ b/cscope.py
@@ -420,13 +420,15 @@ class CscopeCommand(sublime_plugin.TextCommand):
         self.mode = mode
         self.executable = get_setting("executable", "cscope")
 
-        if self.database == None:
-            self.database = CscopeDatabase(view = self.view)
-            self.database.update_location(self.view.file_name())
+        # Create a new database object every time we run. This way, if our user
+        # deleted cscope files or recreated them, we have a correct understanding
+        # of the current state.
+        self.database = CscopeDatabase(view = self.view)
+        self.database.update_location(self.view.file_name())
 
-            if self.database.location == None:
-                sublime.error_message("Could not find cscope database: cscope.out")
-                return
+        if self.database.location == None:
+            sublime.error_message("Could not find cscope database: cscope.out")
+            return
 
         cur_pos = getCurrentPosition(self.view)
         if cur_pos:


### PR DESCRIPTION
Merging my database rebuild branch into master. This cleans up the commands file to use consistent indentation. It moves the cscope database file and root into a new class. This new class is used by the rest of the CscopeSublime plugin to query the cscope database, and also as a standalone class that lets us rebuild the database file from within Sublime Text. Right now, the "rebuild database" functionality is exposed through a right-click on the sidebar and also through the standard command palette.