### PR TITLE
adding missing Preferences > Package Settings menus for configuration

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,34 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "CscopeSublime",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/Cscope/CscopeSublime.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/CscopeSublime.sublime-settings"},
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
I think this is what issue #46 is about. We were missing the Main.sublime-menu file that is required to add configurability via Preferences > Package Settings. This should fix the problem.