### PR TITLE
applying fix/protection for ST2 users

### DIFF
--- a/cscope.py
+++ b/cscope.py
@@ -54,7 +54,12 @@ class CscopeDatabase(sublime_plugin.TextCommand):
             self.rebuild()
 
     def update_location(self, filename):
-        project_info = self.view.window().project_data()
+        project_info = None
+
+        # project_data is only available in ST3. we need to add this check
+        # to not break our plugin for ST2 users. see also issue #51.
+        if hasattr(self.view.window(), 'project_data'):
+            project_info = self.view.window().project_data()
 
         if get_setting("database_location", "") != "":
             self.location = get_setting("database_location", "")


### PR DESCRIPTION
Hopefully this fixes issue #51. I'm not sure what the behaviour for ST2 users will be since it doesn't seem that our plugin can find the cscope database in ST2 without project_info? But at least our plugin shouldn't crash for ST2 users.