### PR TITLE
We should show the arg list we're calling subprocess.Popen and the error if we have problems.

### DIFF
--- a/cscope.py
+++ b/cscope.py
@@ -159,10 +159,8 @@ class CscopeDatabase(object):
         try:
             proc = subprocess.Popen(cscope_arg_list, **popen_arg_list)
         except OSError as e:
-            if e.errno == errno.ENOENT:
-                sublime.error_message("Cscope ERROR: cscope binary \"%s\" not found!" % self.executable)
-            else:
-                sublime.error_message("Cscope ERROR: %s failed!" % cscope_arg_list)
+            sublime.error_message('Cscope ERROR. Command: {} failed! Error: {}'
+                                  .format(cscope_arg_list, e))
 
         output, erroroutput = proc.communicate()
         print('CscopeDatabase: Rebuild done.')
@@ -372,10 +370,8 @@ class CscopeSublimeSearchWorker(threading.Thread):
         try:
             proc = subprocess.Popen(cscope_arg_list, **popen_arg_list)
         except OSError as e:
-            if e.errno == errno.ENOENT:
-                sublime.error_message("Cscope ERROR: cscope binary \"%s\" not found!" % self.executable)
-            else:
-                sublime.error_message("Cscope ERROR: %s failed!" % cscope_arg_list)
+            sublime.error_message('Cscope ERROR. Command: {} failed! Error: {}'
+                                  .format(cscope_arg_list, e))
 
         output, erroroutput = proc.communicate()
 


### PR DESCRIPTION
I hit an error today because sometimes it seems that sublime text is able to launch processes from $PATH and sometimes it is not. And the error confused me because it was saying that I was using the executable. In all cases, let's just show the arg list that we execute and the error, since we weren't showing that either.