### PR TITLE
Results keyboard navigation, keyboard shortcuts and fixes

### DIFF
--- a/CscopeSublime.sublime-settings
+++ b/CscopeSublime.sublime-settings
@@ -31,4 +31,8 @@
     // An optional custom command used to build cscope's database.
     // This must be in array format.
     //"database_build_command": [ "cscope-indexer", "-r" ],
+
+    // On default build command, whether to treat folders in project (after the 1st one) as
+    // additional source directories
+    "auto_next_source_dirs": false,
 }

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -87,7 +87,14 @@
         ],
         "args": {"direction": "down2"}
     },
-    { "keys": ["ctrl+l", "ctrl+x"], "command": "close_cscope_tabs"},
+    { "keys": ["ctrl+l", "ctrl+x"], 
+        "command": "cscope",
+        "args": { "mode": "close_opened_results" }
+    },
+    { "keys": ["ctrl+l", "ctrl+f"], 
+        "command": "cscope",
+        "args": { "mode": "database_rebuild" }
+    },
     {
 	"keys": ["ctrl+shift+["],
     	"command": "goback"

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -52,6 +52,43 @@
         "context": [{"key": "selector", "operand": "text.find-in-files"}]
     },
     {
+        "keys": ["j"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "down"}
+    },
+    {
+        "keys": ["k"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "up"}
+    },
+    {
+        "keys": ["pageup"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "up2"}
+    },
+    {
+        "keys": ["pagedown"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "down2"}
+    },
+    { "keys": ["ctrl+l", "ctrl+x"], "command": "close_cscope_tabs"},
+    {
 	"keys": ["ctrl+shift+["],
     	"command": "goback"
     },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -87,7 +87,14 @@
         ],
         "args": {"direction": "down2"}
     },
-    { "keys": ["ctrl+l", "ctrl+x"], "command": "close_cscope_tabs"},
+    { "keys": ["super+l", "super+x"], 
+        "command": "cscope",
+        "args": { "mode": "close_opened_results" }
+    },
+    { "keys": ["super+l", "super+f"], 
+        "command": "cscope",
+        "args": { "mode": "database_rebuild" }
+    },
     {
 	"keys": ["super+shift+["],
     	"command": "goback"

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -52,6 +52,43 @@
         "context": [{"key": "selector", "operand": "text.find-in-files"}]
     },
     {
+        "keys": ["j"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "down"}
+    },
+    {
+        "keys": ["k"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "up"}
+    },
+    {
+        "keys": ["pageup"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "up2"}
+    },
+    {
+        "keys": ["pagedown"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "down2"}
+    },
+    { "keys": ["ctrl+l", "ctrl+x"], "command": "close_cscope_tabs"},
+    {
 	"keys": ["super+shift+["],
     	"command": "goback"
     },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -87,7 +87,14 @@
         ],
         "args": {"direction": "down2"}
     },
-    { "keys": ["ctrl+l", "ctrl+x"], "command": "close_cscope_tabs"},
+    { "keys": ["ctrl+l", "ctrl+x"], 
+        "command": "cscope",
+        "args": { "mode": "close_opened_results" }
+    },
+    { "keys": ["ctrl+l", "ctrl+f"], 
+        "command": "cscope",
+        "args": { "mode": "database_rebuild" }
+    },
     {
 	"keys": ["ctrl+shift+["],
     	"command": "goback"

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -52,6 +52,43 @@
         "context": [{"key": "selector", "operand": "text.find-in-files"}]
     },
     {
+        "keys": ["j"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "down"}
+    },
+    {
+        "keys": ["k"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "up"}
+    },
+    {
+        "keys": ["pageup"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "up2"}
+    },
+    {
+        "keys": ["pagedown"],
+        "command": "cscope_visiter",
+        "context": [
+            {"key": "selector", "operand": "text.find-in-files"},
+            {"key": "setting.cscope_results"}
+        ],
+        "args": {"direction": "down2"}
+    },
+    { "keys": ["ctrl+l", "ctrl+x"], "command": "close_cscope_tabs"},
+    {
 	"keys": ["ctrl+shift+["],
     	"command": "goback"
     },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -43,5 +43,10 @@
 		"caption": "Cscope: Rebuild database",
 		"command": "cscope",
 		"args": { "mode": "database_rebuild" }
+	},
+    {
+		"caption": "Cscope: Close all opened results",
+		"command": "cscope",
+		"args": { "mode": "close_opened_results" }
 	}
 ]

--- a/Lookup Results.hidden-tmLanguage
+++ b/Lookup Results.hidden-tmLanguage
@@ -9,7 +9,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>(.*):$</string>
+			<string>^(((?!scope: ).)*):$</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>

--- a/cscope.py
+++ b/cscope.py
@@ -131,11 +131,11 @@ class CscopeDatabase(object):
 
             # If we haven't found an existing database location and root
             # directory, and the user has a project defined for this, and
-            # there's only one path in that project, let's just assume that that
+            # there's one or more paths in that project, let's just assume that first
             # path is the root of the project. This should be a safe assumption
             # and should allow us to create an initial database, if one doesn't
             # exist, in a sane place.
-            if self.root is None and self.location is None and len(project_info_paths) == 1:
+            if self.root is None and self.location is None and len(project_info_paths) >= 1:
                 self.root = project_info_paths[0]
                 print('CscopeDatabase: Database not found but setting root: {}'
                       .format(self.root))

--- a/cscope.py
+++ b/cscope.py
@@ -42,12 +42,13 @@ def get_setting(key, default=None, view=None):
         pass
     return get_settings().get(key, default)
 
-def update_result_selection(view, selection_index, selection):
+def update_result_selection(view, selection_index, selection, update_sel=True):
     view.settings().set('cscope_results_sel', selection_index)
     view.add_regions('selection', [selection], 'comment', 'dot')
     view.show(selection)
-    view.sel().clear()
-    view.sel().add(sublime.Region(selection.a, selection.a))
+    if update_sel:
+        view.sel().clear()
+        view.sel().add(sublime.Region(selection.a, selection.a))
 
 
 class CscopeDatabase(object):
@@ -649,5 +650,5 @@ class UpdateCscopeResultSelection(sublime_plugin.ViewEventListener):
         r = self.view.get_regions('results')
         for x in r:
             if x.contains(mouse_point):
-                update_result_selection(self.view, r.index(x), x)
+                update_result_selection(self.view, r.index(x), x, False)
                 break

--- a/cscope.py
+++ b/cscope.py
@@ -26,6 +26,7 @@ CSCOPE_SEARCH_MODES = {
     8: "files #including this file"
 }
 CSCOPE_CMD_DATABASE_REBUILD = "database_rebuild"
+CSCOPE_CMD_CLOSE_OPENED = "close_opened_results"
 
 def get_settings():
     return sublime.load_settings("CscopeSublime.sublime-settings")
@@ -546,6 +547,10 @@ class CscopeCommand(sublime_plugin.TextCommand):
         cscope_view.settings().set('cscope_results_sel', 0)
 
     def run(self, edit, mode):
+        if mode == CSCOPE_CMD_CLOSE_OPENED:
+            [x.close() for x in self.view.window().views() if x.settings().get('cscope_results')]
+            return
+
         self.mode = mode
         self.executable = get_setting("executable", "cscope")
 
@@ -646,7 +651,3 @@ class UpdateCscopeResultSelection(sublime_plugin.ViewEventListener):
             if x.contains(mouse_point):
                 update_result_selection(self.view, r.index(x), x)
                 break
-
-class CloseCscopeTabsCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
-        [x.close() for x in self.view.window().views() if x.settings().get('cscope_results')]

--- a/cscope.py
+++ b/cscope.py
@@ -41,6 +41,13 @@ def get_setting(key, default=None, view=None):
         pass
     return get_settings().get(key, default)
 
+def update_result_selection(view, selection_index, selection):
+    view.settings().set('cscope_results_sel', selection_index)
+    view.add_regions('selection', [selection], 'comment', 'dot')
+    view.show(selection)
+    view.sel().clear()
+    view.sel().add(sublime.Region(selection.a, selection.a))
+
 
 class CscopeDatabase(object):
     def __init__(self, view, executable):
@@ -170,10 +177,32 @@ class CscopeVisiter(sublime_plugin.TextCommand):
     def __init__(self, view):
         self.view = view
 
-    def run(self, edit):
+    def run(self, edit, **args):
         if self.view.settings().get('syntax') == CSCOPE_SYNTAX_FILE:
+            if args.get('direction'):
+                d = args.get('direction')
+                r = self.view.get_regions('results')
+                if r == []:
+                    return
+                view_height = len(r) - 1
+                s = self.view.settings().get('cscope_results_sel')
+                what = {
+                    'up': -1,
+                    'down': 1,
+                    'up2': -20,
+                    'down2': 20
+                }
+                if d not in what:
+                    return
+                s = s + what[d]
+                if s < 0: s = 0
+                if s > view_height: s = view_height
+
+                update_result_selection(self.view, s, r[s])
+                return
+
             root_re = re.compile(r'In folder (.+)')
-            filepath_re = re.compile(r'^(.+):$')
+            filepath_re = re.compile(r'^(((?!scope: ).)+):$')
             filename_re = re.compile(r'([a-zA-Z0-9_\-\.]+):')
             linenum_re = re.compile(r'^\s*([0-9]+)')
 
@@ -295,24 +324,31 @@ class CscopeSublimeSearchWorker(threading.Thread):
     # switch statement for the different formatted output
     # of Cscope's matches.
     def append_match_string(self, match, command_mode, nested):
-        match_string = "{0}".format(match["file"])
+        match_string = {}
+        match_string['main'] = "{0}".format(match["file"])
         if command_mode in [0, 4, 6, 8]:
             if nested:
-                match_string = ("{0:>6}\n{1:>6} [scope: {2}] {3}").format("..", match["line"], match["scope"], match["instance"])
+                match_string['head'] = ("{0:>6}\n").format("..")
+                match_string['main'] = ("{0:>6} [scope: {1}] {2}").format(match["line"], match["scope"], match["instance"])
             else:
-                match_string = ("\n{0}:\n{1:>6} [scope: {2}] {3}").format(match["file"].replace(self.database.root, "."), match["line"], match["scope"], match["instance"])
+                match_string['head'] = ("\n{0}:\n").format(match["file"].replace(self.database.root, "."))
+                match_string['main'] = ("{0:>6} [scope: {1}] {2}").format(match["line"], match["scope"], match["instance"])
         elif command_mode == 1:
             if nested:
-                match_string = ("{0:>6}\n{1:>6} {2}").format("..", match["line"], match["instance"])
+                match_string['head'] = ("{0:>6}\n").format("..")
+                match_string['main'] = ("{0:>6} {1}").format(match["line"], match["instance"])
             else:
-                match_string = ("\n{0}:\n{1:>6} {2}").format(match["file"].replace(self.database.root, "."), match["line"], match["instance"])
+                match_string['head'] = ("\n{0}:\n").format(match["file"].replace(self.database.root, "."))
+                match_string['main'] = ("{0:>6} {1}").format(match["line"], match["instance"])
         elif command_mode in [2, 3]:
             if nested:
-                match_string = ("{0:>6}\n{1:>6} [function: {2}] {3}").format("..", match["line"], match["function"], match["instance"])
+                match_string['head'] = ("{0:>6}\n").format("..")
+                match_string['main'] = ("{0:>6} [function: {1}] {2}").format(match["line"], match["function"], match["instance"])
             else:
-                match_string = ("\n{0}:\n{1:>6} [function: {2}] {3}").format(match["file"].replace(self.database.root, "."), match["line"], match["function"], match["instance"])
+                match_string['head'] = ("\n{0}:\n").format(match["file"].replace(self.database.root, "."))
+                match_string['main'] = ("{0:>6} [function: {1}] {2}").format(match["line"], match["function"], match["instance"])
         elif command_mode == 7:
-                match_string = ("\n{0}:").format(match["file"].replace(self.database.root, "."))
+                match_string['main'] = ("\n{0}:").format(match["file"].replace(self.database.root, "."))
 
         return match_string
 
@@ -395,9 +431,10 @@ class CscopeSublimeSearchWorker(threading.Thread):
     def run(self):
         matches = self.run_cscope(self.mode, self.symbol)
         self.num_matches = len(matches)
-        self.output = "In folder " + self.database.root + \
+        header = "In folder " + self.database.root + \
             "\nFound " + str(len(matches)) + " matches for " + CSCOPE_SEARCH_MODES[self.mode] + \
-             ": " + self.symbol + "\n" + 50*"-" + "\n\n" + "\n".join(matches)
+            ": " + self.symbol + "\n" + 50*"-" + "\n"
+        self.output = [ header, matches ]
 
 
 class CscopeCommand(sublime_plugin.TextCommand):
@@ -505,6 +542,8 @@ class CscopeCommand(sublime_plugin.TextCommand):
 
         cscope_view.set_syntax_file(CSCOPE_SYNTAX_FILE)
         cscope_view.set_read_only(True)
+        cscope_view.settings().set('cscope_results', True)
+        cscope_view.settings().set('cscope_results_sel', 0)
 
     def run(self, edit, mode):
         self.mode = mode
@@ -571,7 +610,43 @@ class CscopeCommand(sublime_plugin.TextCommand):
 class DisplayCscopeResultsCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
-        self.view.insert(edit, CscopeCommand.cscope_output_info['pos'], CscopeCommand.cscope_output_info['text'])
+        r = []
+        header, matches = CscopeCommand.cscope_output_info['text']
+        self.view.insert(edit, CscopeCommand.cscope_output_info['pos'], header)
+        for m in matches:
+            head = '\n' + m['head']
+            start = self.view.size()
+            self.view.insert(edit, start, head)
+            start = self.view.size()
+            self.view.insert(edit, start, m['main'])
+            region = sublime.Region(start, self.view.size())
+            r.append(region)
+        self.view.add_regions('results', r)
+        if r: update_result_selection(self.view, 0, r[0])
         if get_setting("display_outline") == True:
             symbol_regions = self.view.find_all(CscopeCommand.cscope_output_info['symbol'], sublime.LITERAL)
-            self.view.add_regions('cscopesublime-outlines', symbol_regions[1:], "text.find-in-files", "", sublime.DRAW_OUTLINED)
+            self.view.add_regions('cscopesublime-outlines', symbol_regions[1:], "entity.name.filename.find-in-files", "", sublime.DRAW_OUTLINED)
+
+class UpdateCscopeResultSelection(sublime_plugin.ViewEventListener):
+    def __init__(self, *args, **kwargs):
+        super(UpdateCscopeResultSelection, self).__init__(*args, **kwargs)
+        self.mouse_point = -1
+
+    @classmethod
+    def is_applicable(cls, settings):
+        return settings.get('cscope_results')
+
+    def on_selection_modified(self):
+        mouse_point = self.view.sel()[0].a
+        if mouse_point == self.mouse_point:
+            return
+        self.mouse_point = mouse_point
+        r = self.view.get_regions('results')
+        for x in r:
+            if x.contains(mouse_point):
+                update_result_selection(self.view, r.index(x), x)
+                break
+
+class CloseCscopeTabsCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        [x.close() for x in self.view.window().views() if x.settings().get('cscope_results')]

--- a/cscope.py
+++ b/cscope.py
@@ -155,6 +155,14 @@ class CscopeDatabase(object):
         if not (cscope_arg_list and isinstance(cscope_arg_list, list)):
             cscope_arg_list = [self.executable, '-Rbq']
 
+            # If the user has a project with more than one path and we're putting 
+            # the database in the first one, treat other paths as additional source dirs
+            if get_setting('auto_next_source_dirs') and hasattr(self.view.window(), 'project_data'):
+                project_info = self.view.window().project_data()
+                if project_info and 'folders' in project_info and project_info['folders'][0]['path'] == self.root:
+                    for folder in project_info['folders'][1:]:
+                        cscope_arg_list += ["-s", folder['path']]
+
         print('CscopeDatabase: Rebuilding database in directory: {}, using command: {}'
               .format(self.root, cscope_arg_list))
 


### PR DESCRIPTION
Hi,

Here's a bunch of features I added some time ago and would like to share, could be merged to master.
- mainly keyboard navigation of results with vim-like j/k and with page up/page down. Also watching selection change for highlighting result on mouse click, as a side effect navigation with arrows also works :)
- closing opened tabs/views with results with keyboard shortcut, I find it useful (["ctrl+l", "ctrl+x"])
- keyboard shortcut for rebuilding database (["ctrl+l", "ctrl+f"])
- fix for results such as the ones found in case statements ("case SYMBOL:") which were falling in the '(.*):$' regex. Changed in code and syntax file for Lookup Results
- on rebuilding the database, when none is found, set root path to the first path in project paths, even if there is more than one
- and if it has more than one treat the next ones as additional source dirs. Not 100% sure about use cases for that (except for mine), so made it an option, disabled by default
